### PR TITLE
Add missing LDFLAG: '-lcrypto'

### DIFF
--- a/addons/libpla/src/Makefile.am
+++ b/addons/libpla/src/Makefile.am
@@ -8,7 +8,7 @@ INCLUDES += -I/usr/local/include
 
 placonf_SOURCES = ec_io.c gnb.c ec.c ec_hw.c placonf.c
 placonf_CFLAGS = $(INCLUDES)
-placonf_LDFLAGS = -lpla -L.
+placonf_LDFLAGS = -lpla -lcrypto -L.
 
 gen_cert_SOURCES = 
 gen_cert:


### PR DESCRIPTION
Solves the following error:

```
libtool: link: g++ -I../include -I/usr/local/include -g -O2 -o .libs/placonf placonf-ec_io.o placonf-gnb.o placonf-ec.o placonf-ec_hw.o placonf-placonf.o  /home/ubuntu/apagar2/blackadder/addons/libpla/src/.libs/libpla.so -L. -lgmp
/usr/bin/ld: placonf-ec.o: undefined reference to symbol 'EVP_MD_CTX_cleanup@@OPENSSL_1.0.0'
//lib/x86_64-linux-gnu/libcrypto.so.1.0.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[1]: *** [placonf] Error 1
make[1]: Leaving directory `/home/ubuntu/apagar2/blackadder/addons/libpla/src'
make: *** [install-recursive] Error 1
```
